### PR TITLE
feat: add client disconnect logic

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,7 @@
       "license": "ISC",
       "dependencies": {
         "express": "^4.17.1",
+        "lodash": "^4.17.20",
         "package.json": "^2.0.1",
         "react": "^16.13.1",
         "react-dom": "^16.13.1",
@@ -9526,8 +9527,7 @@
     "node_modules/lodash": {
       "version": "4.17.20",
       "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.20.tgz",
-      "integrity": "sha512-PlhdFcillOINfeV7Ni6oF1TAEayyZBoZ8bcshTHqOYJYlrqzRK5hagpagky5o4HfCzzd1TRkXPMFq6cKk9rGmA==",
-      "dev": true
+      "integrity": "sha512-PlhdFcillOINfeV7Ni6oF1TAEayyZBoZ8bcshTHqOYJYlrqzRK5hagpagky5o4HfCzzd1TRkXPMFq6cKk9rGmA=="
     },
     "node_modules/lodash.sortby": {
       "version": "4.7.0",
@@ -22108,8 +22108,7 @@
     "lodash": {
       "version": "4.17.20",
       "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.20.tgz",
-      "integrity": "sha512-PlhdFcillOINfeV7Ni6oF1TAEayyZBoZ8bcshTHqOYJYlrqzRK5hagpagky5o4HfCzzd1TRkXPMFq6cKk9rGmA==",
-      "dev": true
+      "integrity": "sha512-PlhdFcillOINfeV7Ni6oF1TAEayyZBoZ8bcshTHqOYJYlrqzRK5hagpagky5o4HfCzzd1TRkXPMFq6cKk9rGmA=="
     },
     "lodash.sortby": {
       "version": "4.7.0",

--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
   "license": "ISC",
   "dependencies": {
     "express": "^4.17.1",
+    "lodash": "^4.17.20",
     "package.json": "^2.0.1",
     "react": "^16.13.1",
     "react-dom": "^16.13.1",

--- a/src/common/events.js
+++ b/src/common/events.js
@@ -7,6 +7,7 @@ const SocketGameEvents = {
   START_GAME: 'start-game',
   FINISH_ENCODING: 'finish-encoding',
   UPDATE_GUESS: 'update-guess',
+  CLIENT_DISCONNECT: 'disconnecting',
 
   // server -> client events
   ROOM_CREATED: 'room-created',

--- a/src/server/app.js
+++ b/src/server/app.js
@@ -10,6 +10,7 @@ const {
   handleStartGame,
   handleFinishEncoding,
   handleUpdateGuess,
+  handleClientDisconnect,
 } = require('./utils/EventHandlers');
 
 const app = express();
@@ -52,6 +53,10 @@ io.on('connection', (socket) => {
   );
   socket.on(SocketGameEvents.UPDATE_GUESS, (roomId, playerId, guess) => {
     handleUpdateGuess(io, rooms, roomId, playerId, guess);
+  });
+
+  socket.on(SocketGameEvents.CLIENT_DISCONNECT, () => {
+    handleClientDisconnect(socket);
   });
 });
 

--- a/src/server/room.js
+++ b/src/server/room.js
@@ -66,6 +66,24 @@ class Room {
     return true;
   }
 
+  setPlayerInactive(userId) {
+    if (this.playerList[userId] != null && this.playerList[userId].active) {
+      console.log(`ROOM ${this.id}: setting ${userId} to inactive `);
+      this.playerList[userId].active = false;
+      return true;
+    } else if (this.playerList[userId] === null) {
+      console.log(
+        `ROOM ${this.id}: failed to set ${userId} to inactive [user does not exist in room]`
+      );
+      return false;
+    } else if (!this.playerList[userId].active) {
+      console.log(
+        `ROOM ${this.id}: failed to set ${userId} to inactive [user is already inactive]`
+      );
+      return false;
+    }
+  }
+
   addPlayerToTeam(userId, teamId) {
     if (this.playerList[userId] == null) {
       // userId does not exist in this room

--- a/src/server/room.js
+++ b/src/server/room.js
@@ -50,6 +50,16 @@ class Room {
         `ROOM ${this.id}: failed to add player ${userId} [already in playerList]`
       );
       return false;
+    } else if (
+      this.playerList[userId] != null &&
+      !this.playerList[userId].active
+    ) {
+      // This username already exists in the room, and the player is inactive
+      // set them to active and update the playerList with the new socketId
+      console.log(`ROOM ${this.id}: player ${userId} is rejoining`);
+      this.playerList[userId].active = true;
+      this.playerList[userId].socketId = socketId;
+      return true;
     }
     this.playerList[userId] = new Player(userId, socketId);
     console.log(`ROOM ${this.id}: added ${userId} to room`);

--- a/src/server/utils/EventHandlers.js
+++ b/src/server/utils/EventHandlers.js
@@ -11,6 +11,7 @@ const {
   sendRedactedStateUpdates,
   stringifyRoom,
 } = require('./utils');
+var _ = require('lodash');
 
 function handleCreate(
   conn, // client's socket connection
@@ -187,6 +188,37 @@ function handleUpdateGuess(
   });
 }
 
+function handleClientDisconnect(socket) {
+  // if the user has not joined any rooms, then do nothing
+  if (Object.keys(socket.rooms).length < 2) {
+    return;
+  }
+  // get room ID (this is a bit hacky)
+  const roomId = Object.keys(socket.rooms)[1];
+  const socketId = socket.id;
+  const room = rooms[roomId];
+
+  // get player list from room
+  const playerList = room.playerList;
+
+  // playerList is a map of playerId:socketId
+  const playerId = _.findKey(
+    playerList,
+    (player) => player.socketId === socketId
+  );
+
+  // set the player as inactive
+  if (room.setPlayerInactive(playerId)) {
+    console.log(
+      `playerId: ${playerId}, roomId: ${roomId}, socketId: ${socketId} disconnected successfully`
+    );
+  } else {
+    console.log(
+      `playerId: ${playerId}, roomId: ${roomId}, socketId: ${socketId} failed to disconnect`
+    );
+  }
+}
+
 module.exports = {
   handleCreate,
   handleJoinRoom,
@@ -194,4 +226,5 @@ module.exports = {
   handleStartGame,
   handleFinishEncoding,
   handleUpdateGuess,
+  handleClientDisconnect,
 };


### PR DESCRIPTION
## Changes

* [backend] Adds new handler `handleClientDisconnect` for disconnects
* [backend] Adds new function `setPlayerToInactive` for disconnects
* [backend] Updates `addPlayerToRoom` to handle reconnects using the same `userId`/`playerId` + `roomId`

## Notes

Adds new dependencies:

* `lodash`: utilities for dealing with JS objects